### PR TITLE
test(remote_scanner): enhance ScanResultReader with additional test cases

### DIFF
--- a/pkg/scan/remote_scanner.go
+++ b/pkg/scan/remote_scanner.go
@@ -23,8 +23,11 @@ import (
 	"github.com/defenseunicorns/uds-security-hub/pkg/types"
 )
 
-var errOpeningFile = errors.New("error opening file")
-var errDecodingJSON = errors.New("error decoding JSON")
+// ErrOpeningFile is returned when there is an error opening a file.
+var ErrOpeningFile = errors.New("error opening file")
+
+// ErrDecodingJSON is returned when there is an error decoding a JSON file.
+var ErrDecodingJSON = errors.New("error decoding JSON")
 
 // Scanner implements the PackageScanner interface for remote packages.
 type Scanner struct {
@@ -76,14 +79,14 @@ func NewRemotePackageScanner(
 func (s *Scanner) ScanResultReader(result types.PackageScannerResult) (types.ScanResultReader, error) {
 	file, err := os.Open(result.JSONFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", errOpeningFile, err)
+		return nil, fmt.Errorf("%w: %w", ErrOpeningFile, err)
 	}
 	defer file.Close()
 
 	var scanResult types.ScanResult
 	decoder := json.NewDecoder(file)
 	if err := decoder.Decode(&scanResult); err != nil {
-		return nil, fmt.Errorf("%w: %w", errDecodingJSON, err)
+		return nil, fmt.Errorf("%w: %w", ErrDecodingJSON, err)
 	}
 
 	return &scanResultReader{ArtifactNameOverride: result.ArtifactNameOverride, scanResult: scanResult}, nil

--- a/pkg/scan/remote_scanner.go
+++ b/pkg/scan/remote_scanner.go
@@ -23,6 +23,9 @@ import (
 	"github.com/defenseunicorns/uds-security-hub/pkg/types"
 )
 
+var errOpeningFile = errors.New("error opening file")
+var errDecodingJSON = errors.New("error decoding JSON")
+
 // Scanner implements the PackageScanner interface for remote packages.
 type Scanner struct {
 	logger              *slog.Logger
@@ -73,14 +76,14 @@ func NewRemotePackageScanner(
 func (s *Scanner) ScanResultReader(result types.PackageScannerResult) (types.ScanResultReader, error) {
 	file, err := os.Open(result.JSONFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("error opening file: %w", err)
+		return nil, fmt.Errorf("%w: %w", errOpeningFile, err)
 	}
 	defer file.Close()
 
 	var scanResult types.ScanResult
 	decoder := json.NewDecoder(file)
 	if err := decoder.Decode(&scanResult); err != nil {
-		return nil, fmt.Errorf("error decoding JSON: %w", err)
+		return nil, fmt.Errorf("%w: %w", errDecodingJSON, err)
 	}
 
 	return &scanResultReader{ArtifactNameOverride: result.ArtifactNameOverride, scanResult: scanResult}, nil

--- a/pkg/scan/remote_scanner_test.go
+++ b/pkg/scan/remote_scanner_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/defenseunicorns/uds-security-hub/pkg/types"
@@ -51,8 +52,8 @@ func TestNewScanResultReader(t *testing.T) {
 				return
 			}
 			require.NoError(t, err, "Did not expect an error but got one")
-			require.Equal(t, tt.artifactName, got.GetArtifactName(), "Artifact names do not match")
-			require.Len(t, got.GetVulnerabilities(), tt.vulnerabilityCount, "Number of vulnerabilities does not match")
+			assert.Equal(t, tt.artifactName, got.GetArtifactName(), "Artifact names do not match")
+			assert.Len(t, got.GetVulnerabilities(), tt.vulnerabilityCount, "Number of vulnerabilities does not match")
 		})
 	}
 }

--- a/pkg/scan/remote_scanner_test.go
+++ b/pkg/scan/remote_scanner_test.go
@@ -35,13 +35,13 @@ func TestNewScanResultReader(t *testing.T) {
 			name:         "Test with invalid scan result",
 			jsonFilePath: "testdata/invalid.json",
 			wantErr:      true,
-			err:          errDecodingJSON,
+			err:          ErrDecodingJSON,
 		},
 		{
 			name:         "Test with invalid file",
 			jsonFilePath: "testdata/nonexistent.json",
 			wantErr:      true,
-			err:          errOpeningFile,
+			err:          ErrOpeningFile,
 		},
 	}
 

--- a/pkg/scan/remote_scanner_test.go
+++ b/pkg/scan/remote_scanner_test.go
@@ -16,9 +16,7 @@ func TestNewScanResultReader(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name               string
-		want               types.ScanResultReader
 		jsonFilePath       string
-		wantErr            bool
 		err                error
 		artifactName       string
 		vulnerabilityCount int
@@ -26,7 +24,6 @@ func TestNewScanResultReader(t *testing.T) {
 		{
 			name:               "Test with valid scan result",
 			jsonFilePath:       "testdata/scanresult.json",
-			wantErr:            false,
 			err:                nil,
 			artifactName:       "ghcr.io/defenseunicorns/leapfrogai/rag:0.3.1",
 			vulnerabilityCount: 44,
@@ -34,13 +31,11 @@ func TestNewScanResultReader(t *testing.T) {
 		{
 			name:         "Test with invalid scan result",
 			jsonFilePath: "testdata/invalid.json",
-			wantErr:      true,
 			err:          ErrDecodingJSON,
 		},
 		{
 			name:         "Test with invalid file",
 			jsonFilePath: "testdata/nonexistent.json",
-			wantErr:      true,
 			err:          ErrOpeningFile,
 		},
 	}
@@ -50,11 +45,9 @@ func TestNewScanResultReader(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := s.ScanResultReader(types.PackageScannerResult{JSONFilePath: tt.jsonFilePath})
-			if tt.wantErr {
+			if tt.err != nil {
 				require.Error(t, err, "Expected an error but got none")
-				if tt.err != nil {
-					require.ErrorIs(t, err, tt.err, "Expected error %v, but got %v", tt.err, err)
-				}
+				require.ErrorIs(t, err, tt.err, "Expected error %v, but got %v", tt.err, err)
 				return
 			}
 			require.NoError(t, err, "Did not expect an error but got one")

--- a/pkg/scan/testdata/invalid.json
+++ b/pkg/scan/testdata/invalid.json
@@ -1,0 +1,1 @@
+test data


### PR DESCRIPTION
- Added tests for handling invalid JSON input (`invalid.json`)
- Verified error handling when failing to open files
- Utilized `testify/require` for more expressive assertions
- Improved test coverage for `ScanResultReader` method