### PR TITLE
refactored errors to use require and added test case for pkg/scan/scan_result_reader.go

### DIFF
--- a/pkg/scan/scan_result_reader_test.go
+++ b/pkg/scan/scan_result_reader_test.go
@@ -351,3 +351,19 @@ func TestWriteToJSONWriteError(t *testing.T) {
 		t.Fatalf("expected error writing JSON data, got %v", err)
 	}
 }
+
+func TestGetVulnerabilities_EmptyResults(t *testing.T) {
+	r := &scanResultReader{
+		scanResult: types.ScanResult{
+			ArtifactName: "test-artifact",
+			Results: []struct {
+				Vulnerabilities []types.VulnerabilityInfo `json:"Vulnerabilities"`
+			}{},
+		},
+	}
+
+	got := r.GetVulnerabilities()
+	if len(got) != 0 {
+		t.Errorf("Expected empty vulnerabilities, got %v", got)
+	}
+}

--- a/pkg/scan/scan_result_reader_test.go
+++ b/pkg/scan/scan_result_reader_test.go
@@ -286,7 +286,7 @@ func TestWriteToCSV(t *testing.T) {
 
 			var buf bytes.Buffer
 			err := WriteToCSV(&buf, allResults)
-			require.NoError(t, err, "error occured while writing to cvs")
+			require.NoError(t, err, "error occurred while writing to cvs")
 
 			got := buf.String()
 			r := csv.NewReader(strings.NewReader(got))
@@ -352,5 +352,4 @@ func TestGetVulnerabilities_EmptyResults(t *testing.T) {
 
 	got := r.GetVulnerabilities()
 	require.Empty(t, got, "expected empty vulnerabilities, but got %v", got)
-
 }


### PR DESCRIPTION
- refactored errors and `cmp` to use `github.com/stretchr/testify/require` instead of doing a string comparison
- added test case for empty vulnerability results

