### PR TITLE
Refactor: Return concrete types instead of interfaces

### DIFF
--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -28,7 +28,7 @@ func (m *MockHTTPClient) Do(_ *http.Request) (*http.Response, error) {
 }
 
 // NewMockHTTPClient creates a new instance of the MockHTTPClient.
-func NewMockHTTPClient(mockStatus int, mockResp string) types.HTTPClientInterface {
+func NewMockHTTPClient(mockStatus int, mockResp string) *MockHTTPClient {
 	return &MockHTTPClient{
 		mockResp:   mockResp,
 		mockStatus: mockStatus,

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -74,7 +74,7 @@ func (p *prometheusCollector) MetricsHandler() http.Handler {
 // NewPrometheus creates a new prometheusCollector with empty sync.Maps for histograms, gauges, and counters.
 
 // NewPrometheus creates a new prometheusCollector with empty sync.Maps for histograms, gauges, and counters.
-func NewPrometheus(name string) MetricCollector {
+func NewPrometheus(name string) *prometheusCollector {
 	prefix := fmt.Sprintf("%s_%s_function_duration_seconds", "uds_security_hub", name)
 	functionDuration := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -245,9 +245,9 @@ func (p *prometheusCollector) UnregisterGauge(_ context.Context, name string, _ 
 }
 
 // FromContext returns the MetricCollector from the context.
-func FromContext(ctx context.Context, name string) MetricCollector {
+func FromContext(ctx context.Context, name string) *prometheusCollector {
 	c := metrics(collectorKey)
-	if met, ok := ctx.Value(c).(MetricCollector); ok {
+	if met, ok := ctx.Value(c).(*prometheusCollector); ok {
 		return met
 	}
 	return NewPrometheus(name)

--- a/internal/metrics/prometheus_test.go
+++ b/internal/metrics/prometheus_test.go
@@ -165,7 +165,7 @@ func TestMeasureFunctionExecutionTime(t *testing.T) {
 	stopFunc()
 
 	// Validate the histogram
-	histogramVec, ok := collector.(*prometheusCollector).histograms["uds_security_hub_function_duration_seconds"]
+	histogramVec, ok := collector.histograms["uds_security_hub_function_duration_seconds"]
 	if !ok {
 		t.Fatal("histogram 'uds_security_hub_function_duration_seconds' not found")
 	}


### PR DESCRIPTION
- Updated `NewPrometheus` to return a `*prometheusCollector` instead of `MetricCollector`.
- Modified `FromContext` to return a `*prometheusCollector` instead of `MetricCollector`.
- Adjusted test cases to work with the concrete type `*prometheusCollector`.
- Modified the test to work with concrete type `*MockHTTPClient`.