### PR TITLE
Refactor Tests to Utilize Testify's assert and require

### DIFF
--- a/pkg/semver/semver_test.go
+++ b/pkg/semver/semver_test.go
@@ -1,8 +1,10 @@
 package semver
 
 import (
-	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetNMinusTwoSemvers(t *testing.T) {
@@ -11,19 +13,8 @@ func TestGetNMinusTwoSemvers(t *testing.T) {
 
 	expected := []string{"1.0.0", "1.1.0"}
 	result, err := GetNMinusTwoSemvers(versions, n)
-	if err != nil {
-		t.Fatalf("Error: %v", err)
-	}
-
-	if len(result) != len(expected) {
-		t.Fatalf("Expected %d versions, got %d", len(expected), len(result))
-	}
-
-	for i, v := range result {
-		if v != expected[i] {
-			t.Errorf("Expected version %s, got %s", expected[i], v)
-		}
-	}
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
 }
 
 func TestGetNMinusCustomExcludeSemvers(t *testing.T) {
@@ -32,20 +23,9 @@ func TestGetNMinusCustomExcludeSemvers(t *testing.T) {
 	exclude := 3
 
 	expected := []string{"1.0.0"}
-	result, err := GetNMinusTwoSemvers(versions, n, exclude) // Corrected function call
-	if err != nil {
-		t.Fatalf("Error: %v", err)
-	}
-
-	if len(result) != len(expected) {
-		t.Fatalf("Expected %d versions, got %d", len(expected), len(result))
-	}
-
-	for i, v := range result {
-		if v != expected[i] {
-			t.Errorf("Expected version %s, got %s", expected[i], v)
-		}
-	}
+	result, err := GetNMinusTwoSemvers(versions, n, exclude)
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
 }
 
 func TestGetNMinusTwoSemversInvalidN(t *testing.T) {
@@ -53,13 +33,8 @@ func TestGetNMinusTwoSemversInvalidN(t *testing.T) {
 	n := 1 // n is less than excludeCount (which defaults to 2)
 
 	_, err := GetNMinusTwoSemvers(versions, n)
-	if err == nil {
-		t.Fatal("Expected an error but got none")
-	}
-
-	if !errors.Is(err, ErrInvalidN) {
-		t.Fatalf("Expected error %v, got %v", ErrInvalidN, err)
-	}
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidN)
 }
 
 func TestGetNMinusTwoSemversNotEnoughVersions(t *testing.T) {
@@ -67,13 +42,8 @@ func TestGetNMinusTwoSemversNotEnoughVersions(t *testing.T) {
 	n := 3 // More versions requested than available
 
 	_, err := GetNMinusTwoSemvers(versions, n)
-	if err == nil {
-		t.Fatal("Expected an error but got none")
-	}
-
-	if !errors.Is(err, ErrNotEnoughVersions) {
-		t.Fatalf("Expected error %v, got %v", ErrNotEnoughVersions, err)
-	}
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotEnoughVersions)
 }
 
 func TestGetNMinusTwoSemversInvalidVersion(t *testing.T) {
@@ -81,11 +51,6 @@ func TestGetNMinusTwoSemversInvalidVersion(t *testing.T) {
 	n := 3
 
 	_, err := GetNMinusTwoSemvers(versions, n)
-	if err == nil {
-		t.Fatal("Expected an error but got none")
-	}
-
-	if !errors.Is(err, ErrInvalidSemver) {
-		t.Fatalf("Expected error %v, got %v", ErrInvalidSemver, err)
-	}
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidSemver)
 }

--- a/pkg/types/scan_test.go
+++ b/pkg/types/scan_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetArtifactName(t *testing.T) {
@@ -32,9 +34,7 @@ func TestGetArtifactName(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			artifactName := tc.scanResult.GetArtifactName()
 
-			if artifactName != tc.expectedValue {
-				t.Errorf("expected %v, got %v", tc.expectedValue, artifactName)
-			}
+			assert.Equal(t, tc.expectedValue, artifactName, "The artifact names should match")
 		})
 	}
 }
@@ -141,11 +141,14 @@ func TestGetVulnerabilities(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			vulnerabilities := tc.scanResult.GetVulnerabilities()
-			if len(vulnerabilities) == 0 && len(tc.expectedValue) == 0 {
-				return
-			}
-			if diff := cmp.Diff(tc.expectedValue, vulnerabilities); diff != "" {
-				t.Errorf("Mismatch (-expected +got):\n%s", diff)
+
+			if len(tc.expectedValue) == 0 {
+				require.Empty(t, vulnerabilities, "Expected no vulnerabilities")
+			} else {
+				// Using cmp for deep comparison with detailed diff in case of mismatch
+				if diff := cmp.Diff(tc.expectedValue, vulnerabilities); diff != "" {
+					assert.Failf(t, "Vulnerabilities mismatch", "Mismatch (-expected +got):\n%s", diff)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
- **Updated Test Assertions:**
  - Replaced manual error handling (`t.Fatalf`, `t.Errorf`) with Testify's `require.NoError` and `assert` methods for more concise and readable tests.
  - Enhanced error messages for better clarity when tests fail.

- **Improved Test Readability and Maintainability:**
  - Leveraged Testify's assertion library to standardize test patterns across different test files.
  - Simplified conditional checks and error reporting, making tests easier to understand and maintain.

**Affected Files:**
- `internal/external/scan_result_test.go`
- `pkg/semver/semver_test.go`
- `pkg/types/scan_test.go`